### PR TITLE
Parralel version is slower due to the cost of multiple threads updating ...

### DIFF
--- a/src/main/java/com/github/alexvictoor/SumParallelBench.java
+++ b/src/main/java/com/github/alexvictoor/SumParallelBench.java
@@ -1,39 +1,37 @@
 package com.github.alexvictoor;
 
-
 import org.openjdk.jmh.annotations.*;
 
 import java.util.*;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static java.util.Arrays.stream;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.openjdk.jmh.annotations.Level.Invocation;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+import static org.openjdk.jmh.annotations.Scope.Benchmark;
 
-@State(Scope.Benchmark)
-@OutputTimeUnit(TimeUnit.MILLISECONDS)
-@BenchmarkMode(Mode.AverageTime)
+@State(Benchmark)
+@OutputTimeUnit(MILLISECONDS)
+@BenchmarkMode(AverageTime)
 public class SumParallelBench {
 
     public static final int SIZE = 10 * 1024 * 1024;
-    private int[] data;
+    private IntStream stream;
 
-    @Setup
+    @Setup(Invocation)
     public void init() {
         Random rand = new Random();
-        IntStream stream = rand.ints(SIZE);
-        data = stream.toArray();
+        // random stream of 0 and 1
+        stream = rand.ints(SIZE, 0, 2);
     }
 
     @Benchmark
     public Integer sumValues() {
-        IntStream stream = stream(data);
         return stream.sum();
     }
 
     @Benchmark
     public Integer sumValuesInParallel() {
-        IntStream stream = stream(data);
         return stream.parallel().sum();
     }
 


### PR DESCRIPTION
...an AtomicLong
- The state of the benchmarks are now the stream of random integers (and not an array). The parralel version is now slower due to the cost of multiple threads updating an AtomicLong corresponding to the seed of the random generator.
- The integers randomly generated are composed of 0 and 1. The consequence is that the sum is meaningfull. The sum corresponds to the number of 1 in the stream.
